### PR TITLE
Add native AMP support

### DIFF
--- a/comments.php
+++ b/comments.php
@@ -39,13 +39,25 @@ if ( post_password_required() ) {
 			</h2>
 
 			<?php
+				if ( checathlon_is_amp() ) {
+					?>
+					<amp-live-list
+						id="amp-live-comments-list-<?php the_ID(); ?>"
+						<?php echo ( 'asc' === get_option( 'comment_order' ) ) ? ' sort="ascending" ' : ''; ?>
+						data-poll-interval="<?php echo esc_attr( MINUTE_IN_SECONDS * 1000 ); ?>"
+						data-max-items-per-page="<?php echo esc_attr( get_option( 'page_comments' ) ? (int) get_option( 'comments_per_page' ) : 10000 ); ?>"
+					>
+					<?php
+					add_filter( 'navigation_markup_template', 'checathlon_filter_add_amp_live_list_pagination_attribute' );
+				}
+
 				the_comments_navigation( array(
 					'next_text' => esc_html__( 'Newer comments', 'checathlon' ) . checathlon_get_svg( array( 'icon' => 'arrow-circle-right' ) ),
 					'prev_text' => checathlon_get_svg( array( 'icon' => 'arrow-circle-left' ) ) . esc_html__( 'Older comments', 'checathlon' ),
 				) );
 			?>
 
-			<ol class="comment-list">
+			<ol class="comment-list"<?php echo checathlon_is_amp() ? ' items' : ''; ?>>
 				<?php
 					wp_list_comments( array(
 						'style'       => 'ol',
@@ -60,6 +72,16 @@ if ( post_password_required() ) {
 					'next_text' => esc_html__( 'Newer comments', 'checathlon' ) . checathlon_get_svg( array( 'icon' => 'arrow-circle-right' ) ),
 					'prev_text' => checathlon_get_svg( array( 'icon' => 'arrow-circle-left' ) ) . esc_html__( 'Older comments', 'checathlon' ),
 				) );
+
+				if ( checathlon_is_amp() ) {
+					remove_filter( 'navigation_markup_template', 'checathlon_filter_add_amp_live_list_pagination_attribute' );
+					?>
+						<div update>
+							<button class="button" on="tap:amp-live-comments-list-<?php the_ID(); ?>.update"><?php esc_html_e( 'New comment(s)', 'wp-rig' ); ?></button>
+						</div>
+					</amp-live-list>
+					<?php
+				}
 			
 			// If comments are closed and there are comments, let's leave a little note, shall we?
 			if ( ! comments_open() && get_comments_number() && post_type_supports( get_post_type(), 'comments' ) ) : ?>

--- a/functions.php
+++ b/functions.php
@@ -97,6 +97,17 @@ function checathlon_setup() {
 	// Add support for Message Board Plugin.
 	add_theme_support( 'message-board' );
 
+	add_theme_support( 'amp', array(
+		'comments_live_list' => true,
+		'nav_menu_toggle'    => array(
+			'nav_container_id'           => 'site-navigation',
+			'nav_container_toggle_class' => 'toggled',
+			'menu_button_id'             => 'menu-toggle',
+			'menu_button_toggle_class'   => 'toggled',
+			'nav_menu_toggle_state_id'   => 'navMenuToggledOn',
+		),
+	) );
+
 	// Starter content.
 	$starter_content = array(
 		'widgets' => array(
@@ -311,6 +322,11 @@ add_action( 'widgets_init', 'checathlon_widgets_init' );
  * Adds a `js` class to the root `<html>` element when JavaScript is detected.
  */
 function checathlon_javascript_detection() {
+	// Do not print script if AMP.
+	if ( checathlon_is_amp() ) {
+		return;
+	}
+
 	echo "<script>(function(html){html.className = html.className.replace(/\bno-js\b/,'js')})(document.documentElement);</script>\n";
 }
 add_action( 'wp_head', 'checathlon_javascript_detection', 0 );
@@ -394,6 +410,11 @@ function checathlon_scripts() {
 	// Add theme styles.
 	wp_enqueue_style( 'checathlon-style', get_stylesheet_uri(), array(), is_child_theme() ? checathlon_theme_version() : checathlon_theme_version( $dir = 'template' ) );
 
+	// Do not enqueue scripts if in AMP.
+	if ( checathlon_is_amp() ) {
+		return;
+	}
+
 	// Add theme scripts.
 	wp_enqueue_script( 'checathlon-scripts', get_template_directory_uri() . '/assets/js/scripts' . $suffix . '.js', array(), '20160912', true );
 
@@ -408,6 +429,15 @@ function checathlon_scripts() {
 
 }
 add_action( 'wp_enqueue_scripts', 'checathlon_scripts' );
+
+/**
+ * Check whether the current page should be served as AMP content.
+ *
+ * @return bool True if AMP context, false otherwise.
+ */
+function checathlon_is_amp() {
+	return function_exists( 'is_amp_endpoint' ) && is_amp_endpoint();
+}
 
 /**
  * Implement the Custom Header feature.

--- a/header.php
+++ b/header.php
@@ -9,8 +9,17 @@
  * @package Checathlon
  */
 
+$body_classes = get_body_class();
+
+$html_class = ' class="no-js"';
+$body_class = ' class="' . implode( ' ', $body_classes ) . '"';
+if ( checathlon_is_amp() ) {
+	$html_class .= ' [class]="\'no-js\' + ( navMenuToggledOn ? \' disable-scroll\' : \'\' )"';
+	$body_class .= ' [class]="\'' . implode( ' ', $body_classes ) . '\' + ( navMenuToggledOn ? \' main-navigation-open\' : \'\' )"';
+}
+
 ?><!DOCTYPE html>
-<html <?php language_attributes(); ?> class="no-js">
+<html <?php language_attributes(); echo $html_class; ?>>
 <head>
 <meta charset="<?php bloginfo( 'charset' ); ?>">
 <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -20,7 +29,8 @@
 <?php wp_head(); ?>
 </head>
 
-<body <?php body_class(); ?>>
+<body <?php echo $body_class; ?>>
+<?php unset( $body_classes, $html_class, $body_class ); ?>
 <div id="page" class="site">
 	<a class="skip-link screen-reader-text" href="#content"><?php esc_html_e( 'Skip to content', 'checathlon' ); ?></a>
 

--- a/header.php
+++ b/header.php
@@ -14,7 +14,7 @@ $body_classes = get_body_class();
 $html_class = ' class="no-js"';
 $body_class = ' class="' . implode( ' ', $body_classes ) . '"';
 if ( checathlon_is_amp() ) {
-	$html_class .= ' [class]="\'no-js\' + ( navMenuToggledOn ? \' disable-scroll\' : \'\' )"';
+	$html_class .= sprintf( ' [class]="%s"', esc_attr( "'no-js' + ( navMenuToggledOn ? ' disable-scroll' : ''" ) ) );
 	$body_class .= ' [class]="\'' . implode( ' ', $body_classes ) . '\' + ( navMenuToggledOn ? \' main-navigation-open\' : \'\' )"';
 }
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -532,6 +532,21 @@ function checathlon_hide_header_image() {
 }
 
 /**
+ * Filter to add a pagination reference point attribute for amp-live-list when theme supports AMP.
+ *
+ * This is used by the navigation_markup_template filter in the comments template.
+ *
+ * @access private
+ * @link https://www.ampproject.org/docs/reference/components/amp-live-list#pagination
+ *
+ * @param string $markup Navigation markup.
+ * @return string Filtered markup.
+ */
+function checathlon_filter_add_amp_live_list_pagination_attribute( string $markup ) : string {
+	return preg_replace( '/(\s*<[a-z0-9_-]+)/i', '$1 pagination ', $markup, 1 );
+}
+
+/**
  * Returns true if a blog has more than 1 category.
  *
  * @return bool


### PR DESCRIPTION
This PR adds AMP support to the theme.

Demonstrates the following:
* getting rid of JavaScript
* making hamburger menu AMP-compatible (including some custom tweaks specific to how this theme handles them, see `header.php` changes)
* using `amp-live-list` for comments

It's a pretty good representation how easy it can be to add support to a basic theme.

cc @amedina @westonruter